### PR TITLE
Fix host builder compilation issues

### DIFF
--- a/src/Baluma.Emblue.ApiConsumer.App/Baluma.Emblue.ApiConsumer.App.csproj
+++ b/src/Baluma.Emblue.ApiConsumer.App/Baluma.Emblue.ApiConsumer.App.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.2" />
     <PackageReference Include="NLog" Version="5.2.8" />
     <PackageReference Include="NLog.Extensions.Hosting" Version="5.3.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Baluma.Emblue.ApiConsumer.App/Presentation/Program.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Presentation/Program.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using NLog.Extensions.Hosting;
+using NLog.Extensions.Logging;
+using WinFormsApplication = System.Windows.Forms.Application;
+using WinFormsApplicationConfiguration = System.Windows.Forms.ApplicationConfiguration;
 
 namespace Baluma.Emblue.ApiConsumer.App.Presentation;
 
@@ -19,11 +21,11 @@ internal static class Program
         var builder = Host.CreateApplicationBuilder(args);
         builder.Logging.ClearProviders();
         builder.Logging.SetMinimumLevel(LogLevel.Information);
-        builder.Host.UseNLog();
+        builder.Logging.AddNLog();
         ConfigureConfiguration(builder.Configuration, builder.Environment);
         ConfigureServices(builder.Services, builder.Configuration);
 
-        await using var host = builder.Build();
+        using var host = builder.Build();
         await EnsureDatabaseAsync(host.Services);
 
         if (await TryExecuteFromCommandLineAsync(args, host.Services))
@@ -31,13 +33,13 @@ internal static class Program
             return;
         }
 
-        ApplicationConfiguration.Initialize();
+        WinFormsApplicationConfiguration.Initialize();
         using var scope = host.Services.CreateScope();
         var mainForm = scope.ServiceProvider.GetRequiredService<MainForm>();
-        Application.Run(mainForm);
+        WinFormsApplication.Run(mainForm);
     }
 
-    private static void ConfigureConfiguration(ConfigurationManager configuration, HostApplicationBuilderEnvironment environment)
+    private static void ConfigureConfiguration(ConfigurationManager configuration, IHostEnvironment environment)
     {
         configuration.Sources.Clear();
         configuration


### PR DESCRIPTION
## Summary
- configure the Windows Forms host using supported APIs to avoid HostApplicationBuilder compilation errors
- initialize the application with explicit Windows Forms aliases to prevent namespace conflicts
- add the NLog.Extensions.Logging package so the logging pipeline can use NLog without Host builder extensions

## Testing
- dotnet build *(fails: `dotnet`: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4644dade8833184766ba99a7ac265