### PR TITLE
Add file storage impersonation and bearer token support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,8 +19,11 @@ Edite el archivo `src/Baluma.Emblue.ApiConsumer.App/appsettings.json` y complete
 
 - `AutomaticReports:BaseUrl`: URL base de la API (se provee un valor por defecto).
 - `AutomaticReports:ReportsEndpoint`: Endpoint para solicitar los reportes automáticos.
-- `AutomaticReports:Username` y `Password`: Credenciales de acceso.
+- `AutomaticReports:ApiBearerToken`: Token Bearer para autenticar la API (opcional). Si se especifica, se utilizará en lugar de usuario y contraseña.
+- `AutomaticReports:Username` y `Password`: Credenciales de acceso para autenticación básica (solo si no se usa `ApiBearerToken`).
 - `Database:ConnectionString`: cadena de conexión SQLite donde se almacenarán los datos procesados.
+- `FileStorage:Folder`: Carpeta donde se guardarán los archivos descargados.
+- `FileStorage:Domain`, `Username` y `Password`: Credenciales para impersonar al usuario con acceso a la carpeta (opcional).
 
 ## Ejecución por línea de comandos
 

--- a/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IFileStorage.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IFileStorage.cs
@@ -1,0 +1,8 @@
+using System.IO;
+
+namespace Baluma.Emblue.ApiConsumer.Application.Abstractions;
+
+public interface IFileStorage
+{
+    Task SaveAsync(Stream content, string fileName, CancellationToken cancellationToken);
+}

--- a/src/Baluma.Emblue.ApiConsumer.App/Application/Reports/UseCases/ProcessDailyReportUseCase.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Application/Reports/UseCases/ProcessDailyReportUseCase.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Baluma.Emblue.ApiConsumer.Application.Abstractions;
 using Baluma.Emblue.ApiConsumer.Application.Reports.Parsers;
 using Baluma.Emblue.ApiConsumer.Domain.AutomaticReports;
@@ -10,6 +11,7 @@ public sealed class ProcessDailyReportUseCase : IProcessDailyReportUseCase
 {
     private readonly IAutomaticReportClient _automaticReportClient;
     private readonly IReadOnlyDictionary<AutomaticReportType, IReportContentParser> _parsers;
+    private readonly IFileStorage _fileStorage;
     private readonly ITaskExecutionLogRepository _taskExecutionLogRepository;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ILogger<ProcessDailyReportUseCase> _logger;
@@ -17,12 +19,14 @@ public sealed class ProcessDailyReportUseCase : IProcessDailyReportUseCase
     public ProcessDailyReportUseCase(
         IAutomaticReportClient automaticReportClient,
         IEnumerable<IReportContentParser> parsers,
+        IFileStorage fileStorage,
         ITaskExecutionLogRepository taskExecutionLogRepository,
         IDateTimeProvider dateTimeProvider,
         ILogger<ProcessDailyReportUseCase> logger)
     {
         _automaticReportClient = automaticReportClient;
         _parsers = parsers.ToDictionary(parser => parser.ReportType);
+        _fileStorage = fileStorage;
         _taskExecutionLogRepository = taskExecutionLogRepository;
         _dateTimeProvider = dateTimeProvider;
         _logger = logger;
@@ -49,6 +53,11 @@ public sealed class ProcessDailyReportUseCase : IProcessDailyReportUseCase
                 }
 
                 await using var stream = await _automaticReportClient.DownloadReportAsync(descriptor, cancellationToken);
+                await _fileStorage.SaveAsync(stream, descriptor.FileName, cancellationToken);
+                if (stream.CanSeek)
+                {
+                    stream.Seek(0, SeekOrigin.Begin);
+                }
                 await parser.ParseAndPersistAsync(stream, cancellationToken);
                 processedCount++;
             }

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/AutomaticReports/AutomaticReportOptions.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/AutomaticReports/AutomaticReportOptions.cs
@@ -6,6 +6,7 @@ public sealed class AutomaticReportOptions
 
     public string BaseUrl { get; set; } = string.Empty;
     public string ReportsEndpoint { get; set; } = "automatic_reports/";
+    public string ApiBearerToken { get; set; } = string.Empty;
     public string Username { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
 }

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/AutomaticReports/EmblueAutomaticReportClient.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/AutomaticReports/EmblueAutomaticReportClient.cs
@@ -57,14 +57,23 @@ public sealed class EmblueAutomaticReportClient : IAutomaticReportClient
 
     private void ConfigureHttpClient()
     {
-        var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_options.Username}:{_options.Password}"));
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        if (!string.IsNullOrWhiteSpace(_options.ApiBearerToken))
+        {
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiBearerToken);
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(_options.Username) || !string.IsNullOrEmpty(_options.Password))
+        {
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_options.Username}:{_options.Password}"));
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+        }
     }
 
     private static AutomaticReportFileDescriptor MapToDescriptor(AutomaticReportResponse response)
     {
         var url = new Uri(response.Url);
-        var fileName = Path.GetFileNameWithoutExtension(url.LocalPath);
+        var fileName = Path.GetFileName(url.LocalPath);
         return new AutomaticReportFileDescriptor(
             response.FileId,
             url,

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Configuration/FileStorageOptions.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Configuration/FileStorageOptions.cs
@@ -1,0 +1,11 @@
+namespace Baluma.Emblue.ApiConsumer.Infrastructure.Configuration;
+
+public sealed class FileStorageOptions
+{
+    public const string SectionName = "FileStorage";
+
+    public string Folder { get; set; } = string.Empty;
+    public string Domain { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Baluma.Emblue.ApiConsumer.Application.Abstractions;
 using Baluma.Emblue.ApiConsumer.Infrastructure.AutomaticReports;
 using Baluma.Emblue.ApiConsumer.Infrastructure.Configuration;
+using Baluma.Emblue.ApiConsumer.Infrastructure.FileStorage;
 using Baluma.Emblue.ApiConsumer.Infrastructure.Persistence;
 using Baluma.Emblue.ApiConsumer.Infrastructure.TaskExecution;
 using Baluma.Emblue.ApiConsumer.Infrastructure.Time;
@@ -17,6 +18,7 @@ public static class ServiceCollectionExtensions
     {
         services.Configure<AutomaticReportOptions>(configuration.GetSection(AutomaticReportOptions.SectionName));
         services.Configure<DatabaseOptions>(configuration.GetSection(DatabaseOptions.SectionName));
+        services.Configure<FileStorageOptions>(configuration.GetSection(FileStorageOptions.SectionName));
 
         services.AddHttpClient<IAutomaticReportClient, EmblueAutomaticReportClient>();
 
@@ -28,6 +30,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IDailyReportRepository, DailyReportRepository>();
         services.AddScoped<ITaskExecutionLogRepository, TaskExecutionLogRepository>();
+        services.AddSingleton<IFileStorage, ImpersonatingFileStorage>();
         services.AddSingleton<IDateTimeProvider, SystemDateTimeProvider>();
 
         return services;

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/FileStorage/ImpersonatingFileStorage.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/FileStorage/ImpersonatingFileStorage.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using Baluma.Emblue.ApiConsumer.Application.Abstractions;
+using Baluma.Emblue.ApiConsumer.Infrastructure.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Win32.SafeHandles;
+
+namespace Baluma.Emblue.ApiConsumer.Infrastructure.FileStorage;
+
+[SupportedOSPlatform("windows")]
+public sealed class ImpersonatingFileStorage : IFileStorage
+{
+    private const int Logon32LogonNewCredentials = 9;
+    private const int Logon32ProviderWinnt50 = 3;
+
+    private readonly FileStorageOptions _options;
+    private readonly ILogger<ImpersonatingFileStorage> _logger;
+
+    public ImpersonatingFileStorage(IOptions<FileStorageOptions> options, ILogger<ImpersonatingFileStorage> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SaveAsync(Stream content, string fileName, CancellationToken cancellationToken)
+    {
+        if (content is null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("File name must be provided.", nameof(fileName));
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.Folder))
+        {
+            throw new InvalidOperationException("File storage folder is not configured.");
+        }
+
+        fileName = Path.GetFileName(fileName);
+        var targetDirectory = _options.Folder;
+        var targetPath = Path.Combine(targetDirectory, fileName);
+
+        await RunWithImpersonationAsync(async () =>
+        {
+            _logger.LogDebug("Saving report to {Path}", targetPath);
+
+            Directory.CreateDirectory(targetDirectory);
+
+            if (content.CanSeek)
+            {
+                content.Seek(0, SeekOrigin.Begin);
+            }
+
+            await using var fileStream = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true);
+            await content.CopyToAsync(fileStream, cancellationToken);
+
+            if (content.CanSeek)
+            {
+                content.Seek(0, SeekOrigin.Begin);
+            }
+        });
+    }
+
+    private async Task RunWithImpersonationAsync(Func<Task> action)
+    {
+        if (string.IsNullOrWhiteSpace(_options.Username) || string.IsNullOrWhiteSpace(_options.Password))
+        {
+            await action();
+            return;
+        }
+
+        if (!LogonUser(_options.Username, string.IsNullOrWhiteSpace(_options.Domain) ? null : _options.Domain, _options.Password, Logon32LogonNewCredentials, Logon32ProviderWinnt50, out var accessToken))
+        {
+            var error = Marshal.GetLastWin32Error();
+            throw new Win32Exception(error, "Failed to impersonate the configured user.");
+        }
+
+        using (accessToken)
+        {
+            WindowsIdentity.RunImpersonated(accessToken, () => action().GetAwaiter().GetResult());
+        }
+    }
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static extern bool LogonUser(
+        string lpszUsername,
+        string? lpszDomain,
+        string lpszPassword,
+        int dwLogonType,
+        int dwLogonProvider,
+        out SafeAccessTokenHandle phToken);
+}

--- a/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
+++ b/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
@@ -2,11 +2,18 @@
   "AutomaticReports": {
     "BaseUrl": "https://emblue.site/clientes/baluma/54822/",
     "ReportsEndpoint": "automatic_reports/",
+    "ApiBearerToken": "",
     "Username": "",
     "Password": ""
   },
   "Database": {
     "ConnectionString": "Data Source=baluma-emblue.db"
+  },
+  "FileStorage": {
+    "Folder": "\\\\intranet\\dfs1\\AppzData\\Shared\\Files\\Emblue",
+    "Domain": "",
+    "Username": "",
+    "Password": ""
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- allow configuring AutomaticReports with an optional bearer token and preserve full file names when downloading
- introduce a configurable file storage service that impersonates the configured user while saving reports
- document the new settings and extend appsettings.json with file storage options

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e4876c330c833180368816c02be69e