### PR TITLE
Run impersonated actions on a worker thread

### DIFF
--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/FileStorage/ImpersonatingFileStorage.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/FileStorage/ImpersonatingFileStorage.cs
@@ -84,7 +84,10 @@ public sealed class ImpersonatingFileStorage : IFileStorage
 
         using (accessToken)
         {
-            WindowsIdentity.RunImpersonated(accessToken, () => action().ConfigureAwait(false).GetAwaiter().GetResult());
+            await Task.Run(() =>
+            {
+                WindowsIdentity.RunImpersonated(accessToken, () => action().ConfigureAwait(false).GetAwaiter().GetResult());
+            }).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- run the impersonated file save logic on a background thread to avoid blocking the caller thread while waiting for async work

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e49495856c8331bf38d9f88e6bac9f