### PR TITLE
Switch persistence to SQL Server

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@ Edite el archivo `src/Baluma.Emblue.ApiConsumer.App/appsettings.json` y complete
 - `AutomaticReports:ReportsEndpoint`: Endpoint para solicitar los reportes automáticos.
 - `AutomaticReports:ApiBearerToken`: Token Bearer para autenticar la API (opcional). Si se especifica, se utilizará en lugar de usuario y contraseña.
 - `AutomaticReports:Username` y `Password`: Credenciales de acceso para autenticación básica (solo si no se usa `ApiBearerToken`).
-- `Database:ConnectionString`: cadena de conexión SQLite donde se almacenarán los datos procesados.
+- `Database:ConnectionString`: cadena de conexión de SQL Server donde se almacenarán los datos procesados (por ejemplo, `Server=localhost;Database=BalumaEmblue;Trusted_Connection=True;TrustServerCertificate=True;`).
 - `FileStorage:Folder`: Carpeta donde se guardarán los archivos descargados.
 - `FileStorage:Domain`, `Username` y `Password`: Credenciales para impersonar al usuario con acceso a la carpeta (opcional).
 

--- a/src/Baluma.Emblue.ApiConsumer.App/Baluma.Emblue.ApiConsumer.App.csproj
+++ b/src/Baluma.Emblue.ApiConsumer.App/Baluma.Emblue.ApiConsumer.App.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddDbContext<ApiConsumerDbContext>((serviceProvider, options) =>
         {
             var databaseOptions = serviceProvider.GetRequiredService<IOptions<DatabaseOptions>>().Value;
-            options.UseSqlite(databaseOptions.ConnectionString);
+            options.UseSqlServer(databaseOptions.ConnectionString);
         });
 
         services.AddScoped<IDailyReportRepository, DailyReportRepository>();

--- a/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
+++ b/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
@@ -7,7 +7,7 @@
     "Password": ""
   },
   "Database": {
-    "ConnectionString": "Data Source=baluma-emblue.db"
+    "ConnectionString": "Server=localhost;Database=BalumaEmblue;Trusted_Connection=True;TrustServerCertificate=True;"
   },
   "FileStorage": {
     "Folder": "\\\\intranet\\dfs1\\AppzData\\Shared\\Files\\Emblue",


### PR DESCRIPTION
## Summary
- replace the EF Core provider registration to use SQL Server instead of SQLite
- update configuration documentation and defaults to include a SQL Server connection string
- swap the package reference to Microsoft.EntityFrameworkCore.SqlServer

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e49b5ea1b48331b46d2ed7923dbc02