### PR TITLE
Configure EMB_PRE tables and logs

### DIFF
--- a/scripts/create_emb_pre_tables.sql
+++ b/scripts/create_emb_pre_tables.sql
@@ -57,3 +57,18 @@ BEGIN
     );
 END
 GO
+
+IF OBJECT_ID(N'[dbo].[EMB_PRE_TaskExecutionLog]', N'U') IS NULL
+BEGIN
+    CREATE TABLE [dbo].[EMB_PRE_TaskExecutionLog]
+    (
+        [Id] INT IDENTITY(1,1) NOT NULL CONSTRAINT [PK_EMB_PRE_TaskExecutionLog] PRIMARY KEY,
+        [TaskName] NVARCHAR(128) NOT NULL,
+        [Parameters] NVARCHAR(512) NULL,
+        [StartedAtUtc] DATETIME2(7) NOT NULL,
+        [CompletedAtUtc] DATETIME2(7) NULL,
+        [Status] NVARCHAR(32) NOT NULL,
+        [Message] NVARCHAR(1024) NULL
+    );
+END
+GO

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/ApiConsumerDbContext.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/ApiConsumerDbContext.cs
@@ -20,6 +20,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<DailyActivityDetail>(entity =>
         {
+            entity.ToTable("EMB_PRE_DailyActivityDetail");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Email).HasMaxLength(256);
             entity.Property(e => e.Campaign).HasMaxLength(256);
@@ -35,6 +36,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<DailyActionSummary>(entity =>
         {
+            entity.ToTable("EMB_PRE_DailyActionSummary");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Campaign).HasMaxLength(256);
             entity.Property(e => e.Action).HasMaxLength(256);
@@ -66,6 +68,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<TaskExecutionLog>(entity =>
         {
+            entity.ToTable("EMB_PRE_TaskExecutionLog");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.TaskName).HasMaxLength(128);
             entity.Property(e => e.Parameters).HasMaxLength(512);


### PR DESCRIPTION
## Summary
- map EF Core entities to the EMB_PRE_* tables
- extend the SQL helper script to create the EMB_PRE_TaskExecutionLog table alongside the daily report tables

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e49e4f76c48331943833ca4d90ddba