### PR TITLE
Update ods schema mappings

### DIFF
--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/ApiConsumerDbContext.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/ApiConsumerDbContext.cs
@@ -20,7 +20,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<DailyActivityDetail>(entity =>
         {
-            entity.ToTable("EMB_PRE_DailyActivityDetail");
+            entity.ToTable("emblue_DailyActivityDetail", "ods");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Email).HasMaxLength(256);
             entity.Property(e => e.Campaign).HasMaxLength(256);
@@ -36,7 +36,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<DailyActionSummary>(entity =>
         {
-            entity.ToTable("EMB_PRE_DailyActionSummary");
+            entity.ToTable("emblue_DailyActionSummary", "ods");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Campaign).HasMaxLength(256);
             entity.Property(e => e.Action).HasMaxLength(256);
@@ -68,7 +68,7 @@ public sealed class ApiConsumerDbContext : DbContext
 
         modelBuilder.Entity<TaskExecutionLog>(entity =>
         {
-            entity.ToTable("EMB_PRE_TaskExecutionLog");
+            entity.ToTable("emblue_TaskExecutionLog", "ods");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.TaskName).HasMaxLength(128);
             entity.Property(e => e.Parameters).HasMaxLength(512);

--- a/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
+++ b/src/Baluma.Emblue.ApiConsumer.App/appsettings.json
@@ -7,7 +7,7 @@
     "Password": ""
   },
   "Database": {
-    "ConnectionString": "Server=localhost;Database=BalumaEmblue;Trusted_Connection=True;TrustServerCertificate=True;"
+    "ConnectionString": "Server=10.190.4.201;Database=DW;Trusted_Connection=True;TrustServerCertificate=True;"
   },
   "FileStorage": {
     "Folder": "\\\\intranet\\dfs1\\AppzData\\Shared\\Files\\Emblue",


### PR DESCRIPTION
## Summary
- update table mappings to use the ods schema with the new emblue_ prefix
- point the application database connection string to the DW database on 10.190.4.201

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e50b1fb4c0833180348ec93e6376b7