### PR TITLE
Controlar duplicados de reportes diarios por fecha

### DIFF
--- a/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IDailyReportRepository.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IDailyReportRepository.cs
@@ -6,4 +6,6 @@ public interface IDailyReportRepository
 {
     Task SaveDailyActivityDetailsAsync(IEnumerable<DailyActivityDetail> details, CancellationToken cancellationToken);
     Task SaveDailyActionSummariesAsync(IEnumerable<DailyActionSummary> summaries, CancellationToken cancellationToken);
+    Task<bool> ExistsDataForDateAsync(DateOnly date, CancellationToken cancellationToken);
+    Task DeleteDataForDateAsync(DateOnly date, CancellationToken cancellationToken);
 }

--- a/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IDuplicateDataHandler.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Application/Abstractions/IDuplicateDataHandler.cs
@@ -1,0 +1,6 @@
+namespace Baluma.Emblue.ApiConsumer.Application.Abstractions;
+
+public interface IDuplicateDataHandler
+{
+    Task<bool> ConfirmReplacementAsync(DateOnly date, CancellationToken cancellationToken);
+}

--- a/src/Baluma.Emblue.ApiConsumer.App/Application/Reports/UseCases/IProcessDailyReportUseCase.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Application/Reports/UseCases/IProcessDailyReportUseCase.cs
@@ -2,5 +2,5 @@ namespace Baluma.Emblue.ApiConsumer.Application.Reports.UseCases;
 
 public interface IProcessDailyReportUseCase
 {
-    Task ExecuteAsync(DateOnly? date, CancellationToken cancellationToken);
+    Task ExecuteAsync(DateOnly? date, bool isAutomaticExecution, CancellationToken cancellationToken);
 }

--- a/src/Baluma.Emblue.ApiConsumer.App/Domain/TaskExecution/TaskExecutionLog.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Domain/TaskExecution/TaskExecutionLog.cs
@@ -38,4 +38,11 @@ public sealed class TaskExecutionLog
         Message = message;
         CompletedAtUtc = completedAtUtc;
     }
+
+    public void MarkCancelled(string message, DateTime completedAtUtc)
+    {
+        Status = "Cancelled";
+        Message = message;
+        CompletedAtUtc = completedAtUtc;
+    }
 }

--- a/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/DailyReportRepository.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Infrastructure/Persistence/DailyReportRepository.cs
@@ -24,4 +24,43 @@ public sealed class DailyReportRepository : IDailyReportRepository
         await _dbContext.DailyActionSummaries.AddRangeAsync(summaries, cancellationToken);
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task<bool> ExistsDataForDateAsync(DateOnly date, CancellationToken cancellationToken)
+    {
+        var start = date.ToDateTime(TimeOnly.MinValue);
+        var end = start.AddDays(1);
+
+        var hasDetails = await _dbContext.DailyActivityDetails.AnyAsync(
+            detail =>
+                (detail.ActivityDate.HasValue && detail.ActivityDate >= start && detail.ActivityDate < end) ||
+                (detail.SendDate.HasValue && detail.SendDate >= start && detail.SendDate < end),
+            cancellationToken);
+
+        if (hasDetails)
+        {
+            return true;
+        }
+
+        var hasSummaries = await _dbContext.DailyActionSummaries.AnyAsync(
+            summary => summary.Date.HasValue && summary.Date >= start && summary.Date < end,
+            cancellationToken);
+
+        return hasSummaries;
+    }
+
+    public async Task DeleteDataForDateAsync(DateOnly date, CancellationToken cancellationToken)
+    {
+        var start = date.ToDateTime(TimeOnly.MinValue);
+        var end = start.AddDays(1);
+
+        await _dbContext.DailyActivityDetails
+            .Where(detail =>
+                (detail.ActivityDate.HasValue && detail.ActivityDate >= start && detail.ActivityDate < end) ||
+                (detail.SendDate.HasValue && detail.SendDate >= start && detail.SendDate < end))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _dbContext.DailyActionSummaries
+            .Where(summary => summary.Date.HasValue && summary.Date >= start && summary.Date < end)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
 }

--- a/src/Baluma.Emblue.ApiConsumer.App/Presentation/MainForm.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Presentation/MainForm.cs
@@ -29,7 +29,7 @@ public partial class MainForm : Form
             DateOnly? selectedDate = datePicker.Checked
                 ? DateOnly.FromDateTime(datePicker.Value.Date)
                 : null;
-            await _processDailyReportUseCase.ExecuteAsync(selectedDate, CancellationToken.None);
+            await _processDailyReportUseCase.ExecuteAsync(selectedDate, isAutomaticExecution: false, CancellationToken.None);
             statusLabel.Text = "Proceso finalizado correctamente.";
         }
         catch (Exception ex)

--- a/src/Baluma.Emblue.ApiConsumer.App/Presentation/Program.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Presentation/Program.cs
@@ -1,7 +1,9 @@
+using Baluma.Emblue.ApiConsumer.Application.Abstractions;
 using Baluma.Emblue.ApiConsumer.Application.Reports.Parsers;
 using Baluma.Emblue.ApiConsumer.Application.Reports.UseCases;
 using Baluma.Emblue.ApiConsumer.Infrastructure.Extensions;
 using Baluma.Emblue.ApiConsumer.Infrastructure.Persistence;
+using Baluma.Emblue.ApiConsumer.App.Presentation.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +55,7 @@ internal static class Program
     private static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddInfrastructure(configuration);
+        services.AddScoped<IDuplicateDataHandler, DesktopDuplicateDataHandler>();
         services.AddScoped<IReportContentParser, DailyActivityDetailReportParser>();
         services.AddScoped<IReportContentParser, DailyActionSummaryReportParser>();
         services.AddScoped<IProcessDailyReportUseCase, ProcessDailyReportUseCase>();
@@ -84,7 +87,7 @@ internal static class Program
 
             await using var scope = services.CreateAsyncScope();
             var useCase = scope.ServiceProvider.GetRequiredService<IProcessDailyReportUseCase>();
-            await useCase.ExecuteAsync(date, CancellationToken.None);
+            await useCase.ExecuteAsync(date, isAutomaticExecution: true, CancellationToken.None);
             Environment.ExitCode = 0;
             return true;
         }

--- a/src/Baluma.Emblue.ApiConsumer.App/Presentation/Services/DesktopDuplicateDataHandler.cs
+++ b/src/Baluma.Emblue.ApiConsumer.App/Presentation/Services/DesktopDuplicateDataHandler.cs
@@ -1,0 +1,25 @@
+using Baluma.Emblue.ApiConsumer.Application.Abstractions;
+using System.Windows.Forms;
+
+namespace Baluma.Emblue.ApiConsumer.App.Presentation.Services;
+
+public sealed class DesktopDuplicateDataHandler : IDuplicateDataHandler
+{
+    public Task<bool> ConfirmReplacementAsync(DateOnly date, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<bool>(cancellationToken);
+        }
+
+        var message = $"Ya existen datos para la fecha {date:yyyy-MM-dd}. ¿Desea reemplazarlos?";
+        var result = MessageBox.Show(
+            message,
+            "Confirmar reemplazo",
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Question,
+            MessageBoxDefaultButton.Button2);
+
+        return Task.FromResult(result == DialogResult.Yes);
+    }
+}


### PR DESCRIPTION
## Summary
- add a duplicate data handler abstraction and repository helpers to detect and clear daily data by date
- update the daily report use case to delete existing data automatically for CLI runs or prompt the operator in desktop mode
- register a WinForms confirmation handler so operators can cancel or approve overwriting data and track cancellations in the execution log

## Testing
- dotnet build *(fails: .NET SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e50f3d63c883318e557e0fb548e191